### PR TITLE
Add Cloud.gov Support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,9 @@
+source 'https://rubygems.org'
+
+gem 'jekyll'
+gem 'jekyll-sitemap'
+
+group :test do
+  gem 'rake'
+  gem 'minitest'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,51 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.4.0)
+    colorator (1.1.0)
+    ffi (1.9.14)
+    forwardable-extended (2.6.0)
+    jekyll (3.2.1)
+      colorator (~> 1.0)
+      jekyll-sass-converter (~> 1.0)
+      jekyll-watch (~> 1.1)
+      kramdown (~> 1.3)
+      liquid (~> 3.0)
+      mercenary (~> 0.3.3)
+      pathutil (~> 0.9)
+      rouge (~> 1.7)
+      safe_yaml (~> 1.0)
+    jekyll-sass-converter (1.4.0)
+      sass (~> 3.4)
+    jekyll-sitemap (0.11.0)
+      addressable (~> 2.4.0)
+    jekyll-watch (1.5.0)
+      listen (~> 3.0, < 3.1)
+    kramdown (1.12.0)
+    liquid (3.0.6)
+    listen (3.0.8)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+    mercenary (0.3.6)
+    minitest (5.9.0)
+    pathutil (0.14.0)
+      forwardable-extended (~> 2.6)
+    rake (11.2.2)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.7)
+      ffi (>= 0.5.0)
+    rouge (1.11.1)
+    safe_yaml (1.0.4)
+    sass (3.4.22)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  jekyll
+  jekyll-sitemap
+  minitest
+  rake
+
+BUNDLED WITH
+   1.12.5

--- a/manifest.yml
+++ b/manifest.yml
@@ -1,0 +1,12 @@
+---
+applications:
+- buildpack: https://github.com/cloudfoundry/staticfile-buildpack.git
+  disk_quota: 1024M
+  env:
+    FORCE_HTTPS: true
+  instances: 3
+  memory: 64M
+  name: fyem-production
+  path: _site
+  routes:
+    - route: fyem-production.apps.cloud.gov

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "mkdir -p _site/assets/vendor && cp -R node_modules/uswds/src/fonts node_modules/uswds/src/img _site/assets/ && cp node_modules/uswds/dist/js/uswds.min.js _site/assets/vendor/ && jekyll build",
     "serve": "npm run build && jekyll serve --port 4200",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "deploy": "npm run build && cf push"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Create a Manifest File and deploy script for deploying to Cloud.gov.
- Create a Manifest file for Cloud.gov
- Add Gemfile for tests and sitemap functionality
- Add deploy script for building the site and deploying to Cloud.gov
